### PR TITLE
Remove typo from check for lsb_release

### DIFF
--- a/install-develop.sh
+++ b/install-develop.sh
@@ -31,7 +31,7 @@ do_with_root() {
 }
 
 # Detect distribution name
-if [[ `which lsb_releaseX 2>/dev/null` ]]; then
+if [[ `which lsb_release 2>/dev/null` ]]; then
     # lsb_release available
     distrib_name=`lsb_release -is`
 else

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ do_with_root() {
 }
 
 # Detect distribution name
-if [[ `which lsb_releaseX 2>/dev/null` ]]; then
+if [[ `which lsb_release 2>/dev/null` ]]; then
     # lsb_release available
     distrib_name=`lsb_release -is`
 else


### PR DESCRIPTION
Correct typo in check for lsb_release because it caused trouble on a hosted VPS.

This came up from issue #8.