### PR TITLE
Prevent installer from erroring out

### DIFF
--- a/install-develop.sh
+++ b/install-develop.sh
@@ -64,7 +64,7 @@ if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name
     # Install prerequirements
     do_with_root apt-get install -y git python-pip python-dev gcc lm-sensors wireless-tools
 
-elif [[ $distrib_name == "redhat" || $distrib_name == "centos" || [[ $distrib_name == "fedora" ]] || $distrib_name == "Scientific" ]]; then
+elif [[ $distrib_name == "redhat" || $distrib_name == "centos" || $distrib_name == "fedora" || $distrib_name == "Scientific" ]]; then
     # Redhat/CentOS/Fedora/SL
 
     # Install prerequirements

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name
     # Install prerequirements
     do_with_root apt-get install -y --force-yes python-pip python-dev gcc lm-sensors wireless-tools
 
-elif [[ $distrib_name == "redhat" || $distrib_name == "centos" || [[ $distrib_name == "fedora" ]] || $distrib_name == "Scientific" ]]; then
+elif [[ $distrib_name == "redhat" || $distrib_name == "centos" || $distrib_name == "fedora" || $distrib_name == "Scientific" ]]; then
     # Redhat/CentOS/Fedora/SL
 
     # Install prerequirements


### PR DESCRIPTION
The install script was erroring out on Ubuntu on WSL due to a pair of brackets that I believe were accidently added around fedora in a previous commit.
```
Detected system: Ubuntu
/bin/bash: line 59: conditional binary operator expected                                                               
/bin/bash: line 59: syntax error near `$distrib_name'                                                                   
/bin/bash: line 59: `elif [[ $distrib_name == "redhat" || $distrib_name == "centos" || [[ $distrib_name == "fedora" ]] || $distrib_name == "Scientific" ]]; then'
```