### PR TITLE
Added elementary OS distribution to glances auto install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Available for following operating system:
 - CentOS
 - CentOS minimal based
 - Debian
+- elementary OS
 - Fedora
 - LinuxMint
 - Mac OS X

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ echo "Detected system:" $distrib_name
 
 shopt -s nocasematch
 # Let's do the installation
-if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name == "debian" || $distrib_name == "Raspbian" || $distrib_name == "neon" ]]; then
+if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name == "debian" || $distrib_name == "Raspbian" || $distrib_name == "neon" || $distrib_name == "elementary" ]]; then
     # Ubuntu/Debian variants
 
     # Set non interactive mode


### PR DESCRIPTION
I have tested it on my primary elementary OS computer with success.
elementary OS is a Linux distribution based on Ubuntu, so I didn't do much, just added:
`|| $distrib_name == "elementary"` to the Ubuntu/Debian variants condition.