### PR TITLE
Docker python patch

### DIFF
--- a/install-develop.sh
+++ b/install-develop.sh
@@ -57,7 +57,7 @@ if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name
     do_with_root apt-get -y update
 
     # Install prerequirements
-    do_with_root apt-get install -y git python-pip python-dev gcc lm-sensors wireless-tools
+    do_with_root apt-get install -y git python-pip python-dev python-docker gcc lm-sensors wireless-tools
 
 elif [[ $distrib_name == "redhat" ||  $distrib_name == "RedHatEnterpriseServer" || $distrib_name == "centos" || $distrib_name == "fedora" || $distrib_name == "Scientific" ]]; then
     # Redhat/CentOS/Fedora/SL

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name
     do_with_root apt-get -y --force-yes update
 
     # Install prerequirements
-    do_with_root apt-get install -y --force-yes python-pip python-dev gcc lm-sensors wireless-tools
+    do_with_root apt-get install -y --force-yes python-pip python-dev python-docker gcc lm-sensors wireless-tools
 
 elif [[ $distrib_name == "redhat" ||  $distrib_name == "RedHatEnterpriseServer" || $distrib_name == "centos" || $distrib_name == "fedora" || $distrib_name == "Scientific" ]]; then
     # Redhat/CentOS/Fedora/SL


### PR DESCRIPTION
OS: Debian 10.2
Issue: Unable to see docker containers
Log: `ERROR -- docker plugin - Cannot get Docker version ('NoneType' object has no attribute 'version')`
Platform(s):
```
docker -v
Docker version 19.03.5, build 633a0ea838

docker-compose -v
docker-compose version 1.25.1-rc1, build d92e9bee
```
Reference: https://github.com/docker/docker-py/issues/1502

Added python-docker to list of packages to be installed.
