### PR TITLE
apple renamed the Mac OS X distribution name to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available for following operating system:
 - elementary OS
 - Fedora
 - LinuxMint
-- Mac OS X
+- macOS
 - OpenSuse
 - Oracle EL
 - Raspbian

--- a/install-develop.sh
+++ b/install-develop.sh
@@ -25,7 +25,7 @@ if [[ `which lsb_release 2>/dev/null` ]]; then
     # lsb_release available
     distrib_name=`lsb_release -is`
 elif [[ `which sw_vers 2>/dev/null` ]]; then
-    # sw_vers available (for Mac OS X)
+    # sw_vers available (for macOS)
     distrib_name=`sw_vers -productName`
 else
   # try other method...
@@ -114,8 +114,8 @@ elif [[ $distrib_name == "arch" ]]; then
     # Headers not needed for Arch, shipped with regular python packages
     do_with_root apk add py-pip python-dev linux-headers musl-dev lm_sensors wireless-tools
 
-elif [[ $distrib_name == "Mac OS X" ]]; then
-    # Mac OS X support
+elif [[ $distrib_name == "macOS" ]]; then
+    # macOS support
 
     echo "Install Command lines Tools for XCode on your system"
     do_with_root xcode-select --install

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ if [[ `which lsb_release 2>/dev/null` ]]; then
     # lsb_release available
     distrib_name=`lsb_release -is`
 elif [[ `which sw_vers 2>/dev/null` ]]; then
-    # sw_vers available (for Mac OS X)
+    # sw_vers available (for macOS)
     distrib_name=`sw_vers -productName`
 else
     # try other method...
@@ -114,8 +114,8 @@ elif [[ $distrib_name == "arch" ]]; then
     # Headers not needed for Arch, shipped with regular python packages
     do_with_root apk add py-pip python-dev linux-headers musl-dev lm_sensors wireless-tools
 
-elif [[ $distrib_name == "Mac OS X" ]]; then
-    # Mac OS X support
+elif [[ $distrib_name == "macOS" ]]; then
+    # macOS support
 
     echo "Install Command lines Tools for XCode on your system"
     do_with_root xcode-select --install


### PR DESCRIPTION
https://support.apple.com/en-us/HT201260

`
➜  ~ curl -L https://bit.ly/glances | /bin/bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   167  100   167    0     0    469      0 --:--:-- --:--:-- --:--:--   469
100  5321  100  5321    0     0   8446      0 --:--:-- --:--:-- --:--:-- 5196k
Detected system: macOS
Sorry, GlancesAutoInstall script is not compliant with your system.
Please read: https://github.com/nicolargo/glances#installation


➜  ~ sw_vers

ProductName:	macOS
ProductVersion:	11.2.2
BuildVersion:	20D80`