### PR TITLE
Ubuntu 22.04.2 LTS: E: Package 'python-dev' has no installation candi…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ if [[ $distrib_name == "ubuntu" || $distrib_name == "LinuxMint" || $distrib_name
     #do_with_root apt-get -y update
 
     # Install prerequirements
-    do_with_root apt-get install -y python3-pip python-dev python3-docker gcc lm-sensors wireless-tools
+    do_with_root apt-get install -y python3-pip python3-docker gcc lm-sensors wireless-tools
 
 elif [[ $distrib_name == "redhat" ||  $distrib_name == "RedHatEnterprise" ||  $distrib_name == "RedHatEnterpriseServer" || $distrib_name == "centos" || $distrib_name == "fedora" || $distrib_name == "Scientific" ]]; then
     # Redhat/CentOS/Fedora/SL


### PR DESCRIPTION
…date

To fix installation under Ubuntu 22.04.2 LTS:
Detected system: Ubuntu
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python-dev is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source
However the following packages replace it:
  python2-dev python2 python-dev-is-python3

E: Package 'python-dev' has no installation candidate