### PR TITLE
Find symbolic links as well as regular files when searching for release/version files during distro check

### DIFF
--- a/install-develop.sh
+++ b/install-develop.sh
@@ -29,13 +29,13 @@ elif [[ `which sw_vers 2>/dev/null` ]]; then
     distrib_name=`sw_vers -productName`
 else
   # try other method...
-    lsb_files=`find /etc -type f -maxdepth 1 \( ! -wholename /etc/os-release ! -wholename /etc/lsb-release -wholename /etc/\*release -o -wholename /etc/\*version \) 2> /dev/null`
+    lsb_files=`find /etc -type f,l -maxdepth 1 \( ! -wholename /etc/os-release ! -wholename /etc/lsb-release -wholename /etc/\*release -o -wholename /etc/\*version \) 2> /dev/null`
     for file in $lsb_files; do
         if [[ $file =~ /etc/(.*)[-_] ]]; then
             distrib_name=${BASH_REMATCH[1]}
             break
         else
-            echo "Sorry, GlancesAutoInstall develop branch script is not compliant with your system."
+            echo "Sorry, GlancesAutoInstall develop branch script is not compliant with your system. Could not find any /etc/<distribution>-release regular files or symbolic links"
             echo "Please read: https://github.com/nicolargo/glances#installation"
             exit 1
         fi

--- a/install.sh
+++ b/install.sh
@@ -29,13 +29,13 @@ elif [[ `which sw_vers 2>/dev/null` ]]; then
     distrib_name=`sw_vers -productName`
 else
     # try other method...
-    lsb_files=`find /etc -type f -maxdepth 1 \( ! -wholename /etc/os-release ! -wholename /etc/lsb-release -wholename /etc/\*release -o -wholename /etc/\*version \) 2> /dev/null`
+    lsb_files=`find /etc -type f,l -maxdepth 1 \( ! -wholename /etc/os-release ! -wholename /etc/lsb-release -wholename /etc/\*release -o -wholename /etc/\*version \) 2> /dev/null`
     for file in $lsb_files; do
         if [[ $file =~ /etc/(.*)[-_] ]]; then
             distrib_name=${BASH_REMATCH[1]}
             break
         else
-            echo "Sorry, GlancesAutoInstall script is not compliant with your system."
+            echo "Sorry, GlancesAutoInstall script is not compliant with your system. Could not find any /etc/<distribution>-release regular files or symbolic links"
             echo "Please read: https://github.com/nicolargo/glances#installation"
             exit 1
         fi


### PR DESCRIPTION
On Fedora -release files are stored in /usr/lib/ and sym linked into /etc/, I have add `l` to the types in the find command to reflect this. I also added a sentence to the error message to more clearly state what the issue with the installation was.